### PR TITLE
Add notice "msg_verified_email" to NOTICE parser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -300,6 +300,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         case "commercial_success":
                         case "msg_banned":
                         case "msg_duplicate":
+                        case "msg_verified_email":
                         case "msg_subsonly":
                         case "msg_timedout":
                         case "no_help":


### PR DESCRIPTION
This notice occurs when the user needs an e-mail address before he can submit chat messages.

>@msg-id=msg_verified_email :tmi.twitch.tv NOTICE #channel :This room requires a verified email address to chat. Please verify your email at http://www.twitch.tv/settings