### PR TITLE
client: allow a custom logger

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -21,6 +21,8 @@ Each and every options listed below is optional. Running tmi.js without options 
 
 ``channels``: _Array_ - List of channels to join when connected (Default: ``[]``)
 
+``logger``: _Object_ - Custom logger with the methods ``info``, ``warn``, and ``error``
+
 ## Example
 
 ~~~ javascript

--- a/lib/client.js
+++ b/lib/client.js
@@ -73,10 +73,12 @@ var client = function client(opts) {
     this.eventMods = [];
 
     // Create the logger..
-    this.log = logger.createLogger("tmi.js", "error", "raw");
-
-    // Show debug messages ?
-    if (typeof this.opts.options.debug === "undefined" ? false : this.opts.options.debug) { this.log.level("info"); }
+    var level = "error";
+    if (this.opts.options.debug) {
+        // Show debug messages
+        level = "info";
+    }
+    this.log = this.opts.logger || logger.createLogger("tmi.js", level, "raw");
 
     eventEmitter.call(this);
 }

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,17 @@
+var irc = require("../index.js");
+
+describe("client()", function() {
+    it("should default to the stock logger", function() {
+        var client = new irc.client();
+
+        client.log.should.be.ok();
+    });
+
+    it("should allow a custom logger", function() {
+        var client = new irc.client({
+            logger: console
+        });
+
+        client.log.should.be.exactly(console);
+    });
+});


### PR DESCRIPTION
Allow a custom logger to be provided when creating a client.
A logger should be on the options object through a “logger” property.
A custom logger must have the methods “info”, “warn”, and “error”.