### PR TITLE
Add to module.exports if it exists

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1100,7 +1100,7 @@ client.prototype.nosql = {
 };
 
 // Expose everything, for browser and Node.js / io.js
-if (module && module.exports) {
+if (typeof module !== "undefined" && module.exports) {
     module.exports = client;
 }
 if (typeof window !== "undefined") {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1100,9 +1100,10 @@ client.prototype.nosql = {
 };
 
 // Expose everything, for browser and Node.js / io.js
-if (typeof window === "undefined" && module.exports) {
+if (module && module.exports) {
     module.exports = client;
-} else {
+}
+if (typeof window !== "undefined") {
     window.irc = {};
     window.irc.client = client;
 }


### PR DESCRIPTION
In environments like Electron, you have access to both module.exports and window.

Without this change tmi.js would not be accessible through `var tmi = require("tmi.js")`