### PR TITLE
commands: rename color to newColor to avoid name conflict that breaks on safari

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -31,12 +31,12 @@ module.exports = {
             });
         });
     },
-    color: function color(channel, color) {
-        if (typeof color === "undefined") { color = channel; }
+    color: function color(channel, newColor) {
+        if (typeof newColor === "undefined") { newColor = channel; }
 
-        return this._sendCommand(this._getPromiseDelay(), "#jtv", `/color ${color}`, (resolve, reject) => {
+        return this._sendCommand(this._getPromiseDelay(), "#jtv", `/color ${newColor}`, (resolve, reject) => {
             this.once("_promiseColor", (err) => {
-                if (!err) { resolve([color]); }
+                if (!err) { resolve([newColor]); }
                 else { reject(err); }
             });
         });


### PR DESCRIPTION
tmi.js running in Safari throws the following error:

```
[Error] SyntaxError: Cannot declare a parameter named 's' as it shadows the name of a strict mode function.
	(anonymous function) (tmi.js:1)
```

This change renames the `color` variable to `newColor` to avoid that conflict.