### PR TITLE
client: fix ".me" command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -204,7 +204,7 @@ module.exports = {
     say: function say(channel, message) {
         channel = utils.normalizeChannel(channel);
 
-        if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
+        if ((message.startsWith(".") && !message.startsWith("..")) || message.startsWith("/") || message.startsWith("\\")) {
             if (message.substr(1, 3) === "me ") {
                 return this.action(channel, message.substr(4));
             }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -204,13 +204,15 @@ module.exports = {
     say: function say(channel, message) {
         channel = utils.normalizeChannel(channel);
 
-        if (message.toLowerCase().startsWith("/me ") || message.toLowerCase().startsWith("\\me ")) {
-            return this.action(channel, message.substr(4));
-        }
-        else if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
-            return this._sendCommand(this._getPromiseDelay(), channel, message, (resolve, reject) => {
-                resolve([channel]);
-            });
+        if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
+            if (message.substr(1, 3) === "me ") {
+                return this.action(channel, message.substr(4));
+            }
+            else {
+                return this._sendCommand(this._getPromiseDelay(), channel, message, (resolve, reject) => {
+                    resolve([channel]);
+                });
+            }
         }
         return this._sendMessage(this._getPromiseDelay(), channel, message, (resolve, reject) => {
             resolve([channel, message]);


### PR DESCRIPTION
Currently, `.say('#channel', '.me derp')` does not fire an `action` nor a `chat` event. This PR fixes it by not 
checking the prefixes twice.