### PR TITLE
Add tests for messages that should be no-ops.

### DIFF
--- a/test/noop.js
+++ b/test/noop.js
@@ -1,0 +1,38 @@
+var irc = require('../index.js');
+
+var tests = [
+    ':tmi.twitch.tv 002',
+    ':tmi.twitch.tv 003',
+    ':tmi.twitch.tv 004',
+    ':tmi.twitch.tv 375',
+    ':tmi.twitch.tv 376',
+    ':tmi.twitch.tv CAP',
+    '@msg-id=host_on :tmi.twitch.tv NOTICE #schmoopiie',
+    '@msg-id=host_off :tmi.twitch.tv NOTICE #schmoopiie',
+    '@msg-id=slow_on :tmi.twitch.tv NOTICE #schmoopiie',
+    '@msg-id=slow_off :tmi.twitch.tv NOTICE #schmoopiie',
+    ':schmoopiie!schmoopiie@schmoopiie.tmi.twitch.tv 366'
+];
+
+describe('no-op server events', function() {
+    tests.forEach(function(test) {
+        it(`should treat "${test}" as a no-op`, function() {
+            var stopTest = function() {
+                'Should not call this'.should.not.be.ok();
+            };
+
+            var client = new irc.client({
+                logger: {
+                    trace: stopTest,
+                    debug: stopTest,
+                    info: stopTest,
+                    warn: stopTest,
+                    error: stopTest,
+                    fatal: stopTest
+                }
+            });
+
+            client._onMessage({data: test});
+        });
+    });
+});


### PR DESCRIPTION
Should we need to refactor those switch statements in `handleMessage`, it would be nice to have tests for those cases that we shouldn't do anything with. :smile: