### PR TITLE
logger: Use 24 hour time, add tests.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,24 +1,14 @@
+var _ = require('./utils');
+
 var currentLevel = "info";
 var levels = { "trace": 0, "debug": 1, "info": 2, "warn": 3, "error": 4, "fatal": 5 }
 
 function log(level) {
     return function (message) {
         if (levels[level] >= levels[currentLevel]) {
-            console.log(`[${getDateTime()}] ${level}: ${message}`);
+            console.log(`[${_.formatDate(new Date())}] ${level}: ${message}`);
         }
     }
-}
-
-function getDateTime() {
-    var date = new Date();
-
-    var hours = date.getHours();
-    var mins  = date.getMinutes();
-
-    hours = (hours < 10 ? "0" : "") + hours;
-    mins = (mins < 10 ? "0" : "") + mins;
-
-    return hours + ":" + mins + ((hours >= 12) ? "pm" : "am");
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,15 @@ var self = module.exports = {
 		var channel = typeof str === "undefined" || str === null ? "" : str;
 		return channel.charAt(0) === "#" ? channel.toLowerCase() : "#" + channel.toLowerCase();
 	},
+	formatDate: (date) => {
+	    var hours = date.getHours();
+	    var mins  = date.getMinutes();
+
+	    hours = (hours < 10 ? "0" : "") + hours;
+	    mins = (mins < 10 ? "0" : "") + mins;
+
+	    return hours + ":" + mins;
+	},
 	inherits: (ctor, superCtor) => {
 		ctor.super_ = superCtor;
 		ctor.prototype = Object.create(superCtor.prototype, {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-preset-es2015": "6.6.0",
     "babelify": "7.2.0",
     "browserify": "13.0.0",
+    "hook-std": "0.2.0",
     "istanbul": "0.4.2",
     "mkdirp": "0.5.1",
     "mocha": "2.2.5",

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,4 +1,7 @@
+var hookStd = require('hook-std');
 var irc = require("../index.js");
+var log = require("../lib/logger.js");
+var _ = require("../lib/utils.js");
 
 describe("client()", function() {
     it("should default to the stock logger", function() {
@@ -13,5 +16,37 @@ describe("client()", function() {
         });
 
         client.log.should.be.exactly(console);
+    });
+});
+
+describe("log()", function() {
+    it("should log to the console", function() {
+        var out = '';
+        
+        var unhook = hookStd.stdout({silent: true}, function(output) {
+            out += output;
+        });
+        
+        log.setLevel('info');
+        log.info('foobar');
+        
+        unhook();
+        
+        var expected = out.trim();
+        expected.should.containEql('info: foobar');
+    });
+});
+
+describe("_.formatDate()", function() {
+    it("should format 8am", function() {
+        _.formatDate(new Date('2015-01-01 8:00')).should.eql('08:00');
+    });
+    
+    it("should format 8pm", function() {
+        _.formatDate(new Date('2015-01-01 20:00')).should.eql('20:00');
+    });
+    
+    it("should format 8.30pm", function() {
+        _.formatDate(new Date('2015-01-01 20:30')).should.eql('20:30');
     });
 });


### PR DESCRIPTION
* Extracted out the format date function into utils, decoupling it from the log.
* Made the format date function take a `Date` parameter for easier testing.
* Use 24 hour time. If we want 12 hour time we should write `08:30pm` rather than `20:30pm` which is confusing/unnecessary. Personally I think that 12 hour time could be optional, would much rather see 24 by default, it's shorter.