### PR TITLE
client: fix ".me" command (replaces #110)

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -205,7 +205,7 @@ module.exports = {
     say: function say(channel, message) {
         channel = _.channel(channel);
 
-        if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
+        if ((message.startsWith(".") && !message.startsWith("..")) || message.startsWith("/") || message.startsWith("\\")) {
             if (message.substr(1, 3) === "me ") {
                 return this.action(channel, message.substr(4));
             }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -205,13 +205,15 @@ module.exports = {
     say: function say(channel, message) {
         channel = _.channel(channel);
 
-        if (message.toLowerCase().startsWith("/me ") || message.toLowerCase().startsWith("\\me ")) {
-            return this.action(channel, message.substr(4));
-        }
-        else if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
-            return this._sendCommand(this._getPromiseDelay(), channel, message, (resolve, reject) => {
-                resolve([channel]);
-            });
+        if (message.startsWith(".") || message.startsWith("/") || message.startsWith("\\")) {
+            if (message.substr(1, 3) === "me ") {
+                return this.action(channel, message.substr(4));
+            }
+            else {
+                return this._sendCommand(this._getPromiseDelay(), channel, message, (resolve, reject) => {
+                    resolve([channel]);
+                });
+            }
         }
         return this._sendMessage(this._getPromiseDelay(), channel, message, (resolve, reject) => {
             resolve([channel, message]);

--- a/test/commands.js
+++ b/test/commands.js
@@ -649,6 +649,25 @@ describe('commands (identity)', function() {
             client.on('logon', function() {
                 client.say('#local7000', `${prefix}FOO`).then(function (data) {
                     data[0].should.eql('#local7000');
+                    data.length.should.eql(1);
+                    client.disconnect();
+                    cb();
+                });
+            });
+
+            client.connect();
+        });
+    });
+
+    ['..'].forEach(function(prefix) {
+        it(`should handle ${prefix}message say`, function(cb) {
+            var client = this.client;
+
+            client.on('logon', function() {
+                client.say('#local7000', `${prefix}FOO`).then(function (data) {
+                    data[0].should.eql('#local7000');
+                    data[1].should.eql(`${prefix}FOO`);
+                    data.length.should.eql(2);
                     client.disconnect();
                     cb();
                 });

--- a/test/commands.js
+++ b/test/commands.js
@@ -616,7 +616,7 @@ describe('commands (identity)', function() {
         client.connect();
     });
 
-    ['/me', '\\me'].forEach(function(me) {
+    ['/me', '\\me', '.me'].forEach(function(me) {
         it(`should handle ${me} say`, function(cb) {
             var client = this.client;
             var server = this.server;


### PR DESCRIPTION
Currently, `.say('#channel', '.me derp')` does not fire an `action` nor a `chat` event. This PR fixes it by not 
checking the prefixes twice.