### PR TITLE
client: emit boolean with join/part events.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -662,7 +662,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         this.lastJoined = channel;
                         this.channels.push(channel);
                         this.log.info("Joined " + channel);
-                        this.emit("join", channel, _.username(this.getUsername()));
+                        this.emit("join", channel, _.username(this.getUsername()), true);
                     }
 
                     this.userstate[channel] = message.tags;
@@ -749,19 +749,21 @@ client.prototype.handleMessage = function handleMessage(message) {
                         this.lastJoined = channel;
                         this.channels.push(channel);
                         this.log.info(`Joined ${channel}`);
-                        this.emit("join", channel, message.prefix.split("!")[0]);
+                        this.emit("join", channel, message.prefix.split("!")[0], true);
                     }
 
                     // Someone else joined the channel, just emit the join event..
                     if (this.username !== message.prefix.split("!")[0]) {
-                        this.emit("join", channel, message.prefix.split("!")[0]);
+                        this.emit("join", channel, message.prefix.split("!")[0], false);
                     }
                     break;
 
                 // Someone has left the channel..
                 case "PART":
+					var isSelf = false;
                     // Client a channel..
                     if (this.username === message.prefix.split("!")[0]) {
+						isSelf = true;
                         if (this.userstate[channel]) { delete this.userstate[channel]; }
 
                         var index = this.channels.indexOf(channel);
@@ -775,7 +777,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                     }
 
                     // Client or someone else left the channel, emit the part event..
-                    this.emit("part", channel, message.prefix.split("!")[0]);
+                    this.emit("part", channel, message.prefix.split("!")[0], isSelf);
                     break;
 
                 // Received a whisper..

--- a/test/events.js
+++ b/test/events.js
@@ -94,7 +94,8 @@ var events = [{
     data: ':schmoopiie!schmoopiie@schmoopiie.tmi.twitch.tv JOIN #schmoopiie',
     expected: [
         '#schmoopiie',
-        'schmoopiie'
+        'schmoopiie',
+		true
     ]
 }, {
     name: 'mod',
@@ -115,7 +116,8 @@ var events = [{
     data: ':schmoopiie!schmoopiie@schmoopiie.tmi.twitch.tv PART #schmoopiie',
     expected: [
         '#schmoopiie',
-        'schmoopiie'
+        'schmoopiie',
+		true
     ]
 }, {
     name: 'ping',

--- a/test/events.js
+++ b/test/events.js
@@ -95,7 +95,7 @@ var events = [{
     expected: [
         '#schmoopiie',
         'schmoopiie',
-		true
+		false
     ]
 }, {
     name: 'mod',
@@ -117,7 +117,7 @@ var events = [{
     expected: [
         '#schmoopiie',
         'schmoopiie',
-		true
+		false
     ]
 }, {
     name: 'ping',


### PR DESCRIPTION
This new, last argument for the join and part events is `true` when the username is the same as the client.

You no longer have to write unnecessary code to check this:

**Old**

```javascript
client.on('join', (channel, username) => {
    if(username === client.username()) {
        console.log('Joined', channel);
    }
});
```

**New**

```javascript
client.on('join', (channel, username, fromSelf) => {
    if(fromSelf) {
        console.log('Joined', channel);
    }
});
```

Another option would be to emit "join-self" and "part-self" respectively, but I don't think adding more events is necessary.