### PR TITLE
Emit self whispers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -17,7 +17,7 @@ var api = function api(options, callback) {
     // Inside a web application, use jsonp..
     else {
         // Callbacks must match the regex [a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)*
-        var callbackName = "jsonp_callback_" + Math.round(100000 * Math.random());
+        var callbackName = `jsonp_callback_${Math.round(100000 * Math.random())}`;
         window[callbackName] = function(data) {
             delete window[callbackName];
             document.body.removeChild(script);
@@ -26,7 +26,7 @@ var api = function api(options, callback) {
 
         // Inject the script in the document..
         var script = document.createElement("script");
-        script.src = url + (url.indexOf("?") >= 0 ? "&" : "?") + "callback=" + callbackName;
+        script.src = `${url}${url.indexOf("?") >= 0 ? "&" : "?"}callback=${callbackName}`;
         document.body.appendChild(script);
     }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -210,7 +210,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         var self = this;
                         joinQueue.add(function(i) {
                             if (!_.isNull(self.ws) && self.ws.readyState !== 2 && self.ws.readyState !== 3) {
-                                self.ws.send("JOIN " + _.channel(joinChannels[i]));
+                                self.ws.send(`JOIN ${_.channel(joinChannels[i])}`);
                             }
                         }.bind(this, i))
                     }
@@ -661,7 +661,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         this.userstate[channel] = message.tags;
                         this.lastJoined = channel;
                         this.channels.push(channel);
-                        this.log.info("Joined " + channel);
+                        this.log.info(`Joined ${channel}`);
                         this.emit("join", channel, _.username(this.getUsername()), true);
                     }
 
@@ -1058,7 +1058,7 @@ client.prototype._sendMessage = function _sendMessage(delay, channel, message, f
                 }, 350);
             }
 
-            this.ws.send("PRIVMSG " + _.channel(channel) + " :" + message);
+            this.ws.send(`PRIVMSG ${_.channel(channel)} :${message}`);
 
             // Message is an action (/me <message>)..
             if (message.match(/^\u0001ACTION ([^\u0001]+)\u0001$/)) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -760,10 +760,10 @@ client.prototype.handleMessage = function handleMessage(message) {
 
                 // Someone has left the channel..
                 case "PART":
-					var isSelf = false;
+                    var isSelf = false;
                     // Client a channel..
                     if (this.username === message.prefix.split("!")[0]) {
-						isSelf = true;
+                        isSelf = true;
                         if (this.userstate[channel]) { delete this.userstate[channel]; }
 
                         var index = this.channels.indexOf(channel);
@@ -788,8 +788,12 @@ client.prototype.handleMessage = function handleMessage(message) {
                     if (!message.tags.hasOwnProperty("username")) { message.tags.username = message.prefix.split("!")[0]; }
                     message.tags["message-type"] = "whisper";
 
+                    var from = _.channel(message.tags.username);
                     // Emit for both, whisper and message..
-                    this.emits(["whisper", "message"], [[message.tags, message.params[1]], [null, message.tags, message.params[1], false]]);
+                    this.emits(["whisper", "message"], [
+                        [from, message.tags, message.params[1], false],
+                        [from, message.tags, message.params[1], false]
+                    ]);
                     break;
 
                 case "PRIVMSG":

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -429,7 +429,7 @@ module.exports = {
 
         // Send the command to the server and race the Promise against a delay..
         return this._sendCommand(this._getPromiseDelay(), "#jtv", `/w ${username} ${message}`, (resolve, reject) => {
-            let from = _.channel(username),
+            var from = _.channel(username),
                 userstate = _.merge({
                         "message-type": "whisper",
                         "message-id": null,

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -421,9 +421,28 @@ module.exports = {
     // Send an whisper message to a user..
     whisper: function whisper(username, message) {
         username = _.username(username);
+        
+        // The server will not send a whisper to the account that sent it.
+        if (username === this.getUsername()) {
+            return Promise.reject("Cannot send a whisper to the same account.");
+        }
 
         // Send the command to the server and race the Promise against a delay..
         return this._sendCommand(this._getPromiseDelay(), "#jtv", `/w ${username} ${message}`, (resolve, reject) => {
+            let from = _.channel(username),
+                userstate = _.merge({
+                        "message-type": "whisper",
+                        "message-id": null,
+                        "thread-id": null,
+                        username: this.getUsername()
+                    }, this.globaluserstate);
+
+            // Emit for both, whisper and message..
+            this.emits(["whisper", "message"], [
+                [from, userstate, message, true],
+                [from, userstate, message, true]
+            ]);
+
             // At this time, there is no possible way to detect if a message has been sent has been eaten
             // by the server, so we can only resolve the Promise.
             resolve([username, message]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ var self = module.exports = {
 	isURL: (str) => { return RegExp("^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?)(?::\\d{2,5})?(?:[/?#]\\S*)?$","i").test(str); },
 
 	// Return a random justinfan username..
-	justinfan: () => { return "justinfan" + Math.floor((Math.random() * 80000) + 1000); },
+	justinfan: () => { return `justinfan${Math.floor((Math.random() * 80000) + 1000)}`; },
 
 	// Return a valid password..
 	password: (str) => { return str === "SCHMOOPIIE" || "" || null ? "SCHMOOPIIE" : `oauth:${str.toLowerCase().replace("oauth:", "")}`; },
@@ -69,7 +69,7 @@ var self = module.exports = {
 	    hours = (hours < 10 ? "0" : "") + hours;
 	    mins = (mins < 10 ? "0" : "") + mins;
 
-	    return hours + ":" + mins;
+	    return `${hours}:${mins}`;
 	},
 
 	// Inherit the prototype methods from one constructor into another..

--- a/sri.js
+++ b/sri.js
@@ -4,7 +4,7 @@ var fs = require("fs");
 function checksum(input) {
     var hash = crypto.createHash("sha384").update(input, "utf8");
     var hashBase64 = hash.digest("base64");
-    return "sha384-" + hashBase64;
+    return `sha384-${hashBase64}`;
 }
 
 fs.readFile(process.argv[2], (err, data) => {

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -1,5 +1,5 @@
 var WebSocketServer = require('ws').Server;
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 var noop = function() {};
 
@@ -13,7 +13,7 @@ describe('handling authentication', function() {
     beforeEach(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             logger: {
                 error: noop,
                 info: noop

--- a/test/client.js
+++ b/test/client.js
@@ -1,18 +1,18 @@
-var irc = require("../index.js");
+var tmi = require("../index.js");
 
 describe("client()", function() {
     it("should return a new instance of itself", function() {
-        var client = irc.client();
-        client.should.be.an.instanceOf(irc.client);
+        var client = tmi.client();
+        client.should.be.an.instanceOf(tmi.client);
     });
     
     it("should use the 'info' log when debug is set", function() {
-        var client = new irc.client({options: {debug: true}});
+        var client = new tmi.client({options: {debug: true}});
         client.should.be.ok();
     });
     
     it("should normalize channel names", function() {
-        var client = new irc.client({channels: ["avalonstar", "#dayvemsee"]});
+        var client = new tmi.client({channels: ["avalonstar", "#dayvemsee"]});
         client.opts.channels.should.eql(["#avalonstar", "#dayvemsee"]);
     });
     
@@ -23,19 +23,19 @@ describe("client()", function() {
                 message.should.be.ok();
             }
         };
-        var client = new irc.client({logger: logger, connection: {random: 'main'}});
+        var client = new tmi.client({logger: logger, connection: {random: 'main'}});
     });
 });
 
 describe("client getters", function() {
     it("should get options", function() {
         var opts = {options: {debug: true}};
-        var client = new irc.client(opts);
+        var client = new tmi.client(opts);
         client.getOptions().should.eql(opts);
     });
     
     it("should get channels", function() {
-        var client = new irc.client();
+        var client = new tmi.client();
         client.getChannels().should.eql([]);
     });
 });

--- a/test/commands.js
+++ b/test/commands.js
@@ -1,5 +1,5 @@
 var WebSocketServer = require('ws').Server;
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 var noop = function() {};
 
@@ -340,7 +340,7 @@ describe('commands (justinfan)', function() {
     beforeEach(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             connection: {
                 server: 'localhost',
                 port: 7000,
@@ -509,7 +509,7 @@ describe('commands (identity)', function() {
     beforeEach(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             connection: {
                 server: 'localhost',
                 port: 7000

--- a/test/events.js
+++ b/test/events.js
@@ -1,4 +1,4 @@
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 var events = [{
     name: 'action',
@@ -95,7 +95,7 @@ var events = [{
     expected: [
         '#schmoopiie',
         'schmoopiie',
-		false
+        false
     ]
 }, {
     name: 'mod',
@@ -117,7 +117,7 @@ var events = [{
     expected: [
         '#schmoopiie',
         'schmoopiie',
-		false
+        false
     ]
 }, {
     name: 'ping',
@@ -224,6 +224,7 @@ var events = [{
     name: 'whisper',
     data: '@color=#FFFFFF;display-name=Schmoopiie;emotes=;turbo=1;user-type= :schmoopiie!schmoopiie@schmoopiie.tmi.twitch.tv WHISPER martinlarouche :Hello! ;-)',
     expected: [
+        '#schmoopiie',
         {
             color: '#FFFFFF',
             'display-name': 'Schmoopiie',
@@ -234,7 +235,8 @@ var events = [{
             username: 'schmoopiie',
             'message-type': 'whisper'
         },
-        'Hello! ;-)'
+        'Hello! ;-)',
+        false
     ]
 }];
 
@@ -244,7 +246,7 @@ describe('client events', function() {
         var data = e.data;
         var expected = e.expected;
         it(`should emit ${name}`, function(cb) {
-            var client = new irc.client();
+            var client = new tmi.client();
 
             client.on(name, function() {
                 var args = Array.prototype.slice.call(arguments);
@@ -260,7 +262,7 @@ describe('client events', function() {
     });
 
     it('should emit disconnected', function(cb) {
-        var client = new irc.client();
+        var client = new tmi.client();
 
         client.on("disconnected", function(reason) {
             reason.should.be.exactly("Connection closed.").and.be.a.String();

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -1,4 +1,4 @@
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 var tests = [
     'FOO',
@@ -11,7 +11,7 @@ var tests = [
 describe('invalid server events', function() {
     tests.forEach(function(test) {
         it(`should treat "${test}" as invalid`, function() {
-            var client = new irc.client({
+            var client = new tmi.client({
                 logger: {
                     warn: function(message) {
                         message.includes('Could not parse').should.be.ok;

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,17 +1,17 @@
 var hookStd = require('hook-std');
-var irc = require("../index.js");
+var tmi = require("../index.js");
 var log = require("../lib/logger.js");
 var _ = require("../lib/utils.js");
 
 describe("client()", function() {
     it("should default to the stock logger", function() {
-        var client = new irc.client();
+        var client = new tmi.client();
 
         client.log.should.be.ok();
     });
 
     it("should allow a custom logger", function() {
-        var client = new irc.client({
+        var client = new tmi.client({
             logger: console
         });
 

--- a/test/noop.js
+++ b/test/noop.js
@@ -1,4 +1,4 @@
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 var tests = [
     ':tmi.twitch.tv 002',
@@ -21,7 +21,7 @@ describe('no-op server events', function() {
                 'Should not call this'.should.not.be.ok();
             };
 
-            var client = new irc.client({
+            var client = new tmi.client({
                 logger: {
                     trace: stopTest,
                     debug: stopTest,

--- a/test/websockets.js
+++ b/test/websockets.js
@@ -1,11 +1,11 @@
 var WebSocketServer = require('ws').Server;
-var irc = require('../index.js');
+var tmi = require('../index.js');
 
 describe('websockets', function() {
     before(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             connection: {
                 server: 'localhost',
                 port: 7000
@@ -52,7 +52,7 @@ describe('server crashed, with reconnect: false (default)', function() {
     before(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             connection: {
                 server: 'localhost',
                 port: 7000
@@ -83,7 +83,7 @@ describe('server crashed, with reconnect: true', function() {
     before(function() {
         // Initialize websocket server
         this.server = new WebSocketServer({port: 7000});
-        this.client = new irc.client({
+        this.client = new tmi.client({
             connection: {
                 server: 'localhost',
                 port: 7000,


### PR DESCRIPTION
This pull request will alter the "whisper" and "message" events to include as much information as possible. The `channel` argument will no longer be `null` and will contain the channel-formatted name of the other user in the conversation. The "whisper" event callback arguments now match the other chat-type events including the "self" argument whether or not the message was sent since it already resolves either way.

This pull request also changes some string concatenations to "template strings where sane" and to match some other string concatenations elsewhere.

This also changes the tests' library declarations of `irc` to `tmi` instead.

#### Example

```javascript
const tmi = require('tmi.js');

let client = new tmi.client({
            identity:{
                    username: 'alcabot',
                    password: '...'
                }
        });

client.on('whisper', (from, user, message, fromSelf) => {
        if(fromSelf) {
            console.log(`Sent message to ${from} as ${user.username}: ${message}`);
            return false;
        }
        console.log(`Received message from ${from}: ${message}`);
        /* ... */
    });

client.on('message', (channel, user, message, fromSelf) => {
        if(fromSelf) {
            console.log(`Sent message to ${channel} as ${user.username}: ${message}`);
            return false;
        }
        console.log(`Received message from ${channel}: ${message}`);
        /* ... */
    });

client.connect()
    .then(() => client.whisper('alca', 'Hello'));
```

##### Output:

```
$ node script.js
Sent message to #alca as alcabot: Hello
Sent message to #alca as alcabot: Hello
Received message from #alca: Well hello
Received message from #alca: Well hello
```